### PR TITLE
fix: associated the `color` attribute of the Ellipse node, with the node figure.

### DIFF
--- a/main_window.e
+++ b/main_window.e
@@ -362,7 +362,7 @@ feature -- Event
 		do
 			if attached tree_service.next_on_dfs as node then
 				if attached {ELLIPSE_NODE} world.figure_from_model (node) as fig then
-					fig.set_color (create {EV_COLOR}.make_with_rgb (.1, .1, .1))
+					fig.set_color (create {EV_COLOR}.make_with_rgb (.5, .5, 1))
 					print (fig.color.blue)
 					fig.set_size (50)
 					fig.set_point_position_relative (1, 1)

--- a/shapes/ellipse_node.e
+++ b/shapes/ellipse_node.e
@@ -36,10 +36,10 @@ feature {NONE} -- Initialization
 			bring_to_front (name_label)
 			node_figure.set_radius1 (figure_size)
 			node_figure.set_radius2 (figure_size // 2)
+			node_figure.set_background_color (color)
 			disable_scaling
 			disable_rotating
 			set_center
-
 		end
 
 feature -- Access
@@ -61,12 +61,13 @@ feature -- Element change
 			is_update_required := False
 		end
 
-	set_color(col: EV_COLOR)
+	set_color (col: EV_COLOR)
 		do
 			color := col
+			node_figure.set_background_color (col)
 		end
 
-	set_size(sz: INTEGER)
+	set_size (sz: INTEGER)
 		do
 			fig_size := sz
 		end


### PR DESCRIPTION
(changed the color to be blue, so the text of the node is still visible)